### PR TITLE
:ambulance: Fixed issue where user couldn't remove matches

### DIFF
--- a/views/likedpage.ejs
+++ b/views/likedpage.ejs
@@ -20,7 +20,7 @@
                     <% for (let i = 0; i < data.matches.length; i++) { %>
                         <li>
                             <figure>
-                                <img data-id="<%= data.matches[i].id %>" src="../static/images/<%= data.matches[i].photo %>" alt="Profilepicture">
+                                <img data-id="<%= data.matches[i]._id %>" src="../static/images/<%= data.matches[i].photo %>" alt="Profilepicture">
                                 <figcaption>
                                     <h4><%= data.matches[i].name %></h4>
                                     <p><%= data.matches[i].msg %> Last sent message here.</p>


### PR DESCRIPTION
The delete buttons for the matches (on the liked page) were still using the old custom IDs. I replaced them with the MongoIDs, so these MongoIDs get added to our users "hasDisliked" array, if he chooses to delete them.

Closes #17 